### PR TITLE
[misc]: change {username} to %USERNAME% and add proper local path

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ This plugin allows you to use PowerToys Run for translations via the DeepL API.
    - Download the plugin zip file from [DeepLTranslator Plugin releases](https://github.com/patcher454/DeepLTranslatorPowerToys/releases/).
    - Extract the zip file to:
      ```
+     %LOCALAPPDATA%/Microsoft/PowerToys/PowerToys Run/Plugins
+     ```
+     OR
+     ```
      C:\Program Files\PowerToys\RunPlugins
      ```
      OR

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This plugin allows you to use PowerToys Run for translations via the DeepL API.
      ```
      OR
      ```
-     C:\Users\{username}\AppData\Local\PowerToys\RunPlugins
+     C:\Users\%USERNAME%\AppData\Local\PowerToys\RunPlugins
      ```
 3. **Restart PowerToys:** Exit and restart PowerToys.
 


### PR DESCRIPTION
Windows env variables are acessed trough %<var_name>%

Just a small change on the README.md file to help people that just want to copy and paste the plugins path